### PR TITLE
add exponential decay animations to the qubits

### DIFF
--- a/qubit-quilt/qubit.gd
+++ b/qubit-quilt/qubit.gd
@@ -7,7 +7,7 @@ const DECAY_SPEED: float = 0.04
 # no need to recalculate the angle every time
 const angle_90 = deg_to_rad(90)
 
-var rot: Basis # the current "target" rotation
+var rot: Basis # the "target" rotation
 var is_rotating: bool
 
 func _ready():
@@ -21,9 +21,12 @@ func _ready():
 	self.rot = self.transform.basis
 
 func _process(delta: float) -> void:
+	# don't do the calculations if the qubit is in a stationary state
 	if not self.is_rotating:
 		return
+	# interpolate between the current and the target rotations and update the current rotation
 	self.transform.basis = self.transform.basis.slerp(rot, 1 - DECAY_SPEED ** delta).orthonormalized()
+	# if the target rotation is reached, stop updating the qubit
 	if self.transform.basis.is_equal_approx(rot):
 		self.is_rotating = false
 
@@ -43,6 +46,7 @@ func _on_input_event(_cam: Node, event: InputEvent, _event_position: Vector3, _n
 			rotation_axis = self.rot.y
 		else:
 			return  # Unknown button
-		#actually rotate the qubit
+
+		# calculate the new target rotation for the qubit and set it to be rotating
 		self.rot = self.rot.rotated(rotation_axis, angle_90)
 		self.is_rotating = true

--- a/qubit-quilt/qubit.gd
+++ b/qubit-quilt/qubit.gd
@@ -3,9 +3,12 @@ extends StaticBody3D
 
 var button_group: ButtonGroup
 
+const DECAY_SPEED: float = 0.04
 # no need to recalculate the angle every time
-const angle_radians = deg_to_rad(90)
+const angle_90 = deg_to_rad(90)
 
+var rot: Basis # the current "target" rotation
+var is_rotating: bool
 
 func _ready():
 	# this should be any of the buttons in the Hotbar, 
@@ -13,10 +16,16 @@ func _ready():
 	var button = get_node("/root/Scene/HUD/Hotbar/X-90")
 	button_group = button.button_group
 	# start by rotating the qubit so blue (|0>) is towards the camera and |+> is on the underside
-	self.rotate_object_local(Vector3.RIGHT, angle_radians)
-	self.rotate_object_local(Vector3.UP, -angle_radians)
-	
+	self.rotate_object_local(Vector3.RIGHT, angle_90)
+	self.rotate_object_local(Vector3.UP, -angle_90)
+	self.rot = Quaternion(self.transform.basis)
 
+func _process(delta: float) -> void:
+	if not self.is_rotating:
+		return
+	self.transform.basis = self.transform.basis.slerp(rot, 1 - DECAY_SPEED ** delta).orthonormalized()
+	if self.transform.basis.is_equal_approx(rot):
+		self.is_rotating = false
 
 func _on_input_event(_cam: Node, event: InputEvent, _event_position: Vector3, _normal: Vector3, _shape_idx: int) -> void:
 	# the user clicked on the qubit
@@ -27,13 +36,13 @@ func _on_input_event(_cam: Node, event: InputEvent, _event_position: Vector3, _n
 		if pressed == null: # no pressed button, do nothing (future panning around)
 			return
 		elif pressed.name == "X-90":
-			rotation_axis = Vector3.RIGHT
+			rotation_axis = self.rot.x
 		elif pressed.name == "Y-90":
-			rotation_axis = Vector3.FORWARD
+			rotation_axis = -self.rot.z
 		elif pressed.name == "Z-90":
-			rotation_axis = Vector3.UP
+			rotation_axis = self.rot.y
 		else:
 			return  # Unknown button
-		
 		#actually rotate the qubit
-		self.rotate_object_local(rotation_axis, angle_radians)
+		self.rot = self.rot.rotated(rotation_axis, angle_90)
+		self.is_rotating = true

--- a/qubit-quilt/qubit.gd
+++ b/qubit-quilt/qubit.gd
@@ -18,7 +18,7 @@ func _ready():
 	# start by rotating the qubit so blue (|0>) is towards the camera and |+> is on the underside
 	self.rotate_object_local(Vector3.RIGHT, angle_90)
 	self.rotate_object_local(Vector3.UP, -angle_90)
-	self.rot = Quaternion(self.transform.basis)
+	self.rot = self.transform.basis
 
 func _process(delta: float) -> void:
 	if not self.is_rotating:


### PR DESCRIPTION
Adds an animation to the qubits, changing the variable `rot` makes the qubit try to go towards it.
Makes actions much clearer I feel

Fixes #31 