### PR TITLE
force one of the hotbar buttons to be selected always

### DIFF
--- a/qubit-quilt/hud.tscn
+++ b/qubit-quilt/hud.tscn
@@ -21,7 +21,6 @@ Button/styles/normal = SubResource("StyleBoxTexture_61f8s")
 [sub_resource type="ButtonGroup" id="ButtonGroup_640wx"]
 resource_local_to_scene = false
 resource_name = "controls"
-allow_unpress = true
 
 [node name="HUD" type="CanvasLayer"]
 


### PR DESCRIPTION
From letting my mom play with the site, I noticed that she'd double click the hotbar buttons sometimes, which would turn them back off. This is not intended, so removing the ability to have no buttons selected